### PR TITLE
Unset resource requests for staging

### DIFF
--- a/helm-charts/app/staging/staging.values.yaml
+++ b/helm-charts/app/staging/staging.values.yaml
@@ -1,4 +1,8 @@
 frx-challenges:
+  evaluator:
+    resources: null
+  dind:
+    resources: null
   ingress:
     hosts:
       - staging.cellmapchallenge.2i2c.cloud


### PR DESCRIPTION
This means the evaluator isn't going to be functional on staging, but it means we only run 1 node instead of 2